### PR TITLE
Fix exports and shading formatting

### DIFF
--- a/src/coral_complexity_metrics/__init__.py
+++ b/src/coral_complexity_metrics/__init__.py
@@ -156,9 +156,11 @@ def validate_and_repair_mesh(*args, **kwargs):
 
 # Legacy compatibility
 try:
-    from .mesh.quadrat_metrics import quadrat_metrics_on_mesh
     from .mesh.complexity_metrics import *
     from .mesh.geometric_measures import *
+    # Expose commonly used classes at the package level for convenience.
+    QuadratMetrics = mesh.QuadratMetrics
+    GeometricMeasures = mesh.GeometricMeasures
 except ImportError:
     pass  # These will be handled by the placeholder functions
 
@@ -173,4 +175,7 @@ __all__ = [
     # Convenience functions
     'list_available_metrics', 'get_available_metrics',
     'process_mesh_with_shapefile', 'validate_and_repair_mesh',
+
+    # Frequently used classes from the mesh module
+    'QuadratMetrics', 'GeometricMeasures',
 ]

--- a/src/coral_complexity_metrics/mesh/__init__.py
+++ b/src/coral_complexity_metrics/mesh/__init__.py
@@ -25,7 +25,7 @@ from .shading_modules import *
 # Optional imports - these require heavy dependencies
 try:
     from .mesh_validator import MeshValidator, MeshValidationResult, batch_validate_meshes
-    from .quadrat_metrics import quadrat_metrics_on_mesh
+    from .quadrat_metrics import QuadratMetrics
     from .complexity_metrics import *
     from .geometric_measures import *
     
@@ -45,7 +45,6 @@ except ImportError as e:
     MeshValidator = _missing_dependency_warning("MeshValidator")
     MeshValidationResult = _missing_dependency_warning("MeshValidationResult") 
     batch_validate_meshes = _missing_dependency_warning("batch_validate_meshes")
-    quadrat_metrics_on_mesh = _missing_dependency_warning("quadrat_metrics_on_mesh")
     
     # Set availability flags
     _VALIDATION_AVAILABLE = False
@@ -108,5 +107,4 @@ __all__ = [
     
     # Legacy components
     'GeometricMeasures', 'LegacyQuadratMetrics',
-    'quadrat_metrics_on_mesh',
 ]

--- a/src/coral_complexity_metrics/mesh/_internal/__init__.py
+++ b/src/coral_complexity_metrics/mesh/_internal/__init__.py
@@ -6,19 +6,22 @@ They are not part of the public API and may change without notice.
 """
 
 # Legacy internal modules
-from ._dimension_order import DimensionOrder
-from ._face import Face
-from ._helpers import get_z_value, mean, sd, get_midpoint_of_edge
-from ._mesh import Mesh
-from ._mesh_io import MeshIO
-from ._quadrat import Quadrat
-from ._quadrat_builder import QuadratBuilder
-from ._quadrilateral import Quadrilateral
-from ._shading_utils import AABB, BVHNode
-from ._vertex import Vertex
+# NOTE: these modules live one level above this package. Use ``..`` imports so
+# they resolve correctly when ``_internal`` is imported.  Using ``.`` relative
+# imports here results in ``ImportError`` because Python looks for the modules
+# inside the ``_internal`` package.
+from .._dimension_order import DimensionOrder
+from .._face import Face
+from .._helpers import get_z_value, mean, sd, get_midpoint_of_edge
+from .._mesh import Mesh
+from .._quadrat import Quadrat
+from .._quadrat_builder import QuadratBuilder
+from .._quadrilateral import Quadrilateral
+from .._shading_utils import AABB, BVHNode
+from .._vertex import Vertex
 
 __all__ = [
     'DimensionOrder', 'Face', 'get_z_value', 'mean', 'sd', 'get_midpoint_of_edge',
-    'Mesh', 'MeshIO', 'Quadrat', 'QuadratBuilder', 'Quadrilateral',
+    'Mesh', 'Quadrat', 'QuadratBuilder', 'Quadrilateral',
     'AABB', 'BVHNode', 'Vertex'
 ]

--- a/src/coral_complexity_metrics/mesh/quadrat_metrics.py
+++ b/src/coral_complexity_metrics/mesh/quadrat_metrics.py
@@ -1,8 +1,12 @@
-from ._internal._dimension_order import DimensionOrder
-from ._internal._quadrat_builder import QuadratBuilder
-from ._internal._quadrilateral import Quadrilateral
-from ._internal._vertex import Vertex
-from ._internal._mesh_io import read_obj
+# The helper modules originally lived in a separate ``_internal`` package.  In
+# this trimmed-down version they sit directly under ``mesh``.  Import them
+# directly so that this module works regardless of whether ``_internal`` exists
+# as a real subpackage.
+from ._dimension_order import DimensionOrder
+from ._quadrat_builder import QuadratBuilder
+from ._quadrilateral import Quadrilateral
+from ._vertex import Vertex
+from ._mesh_io import read_obj
 from tqdm import tqdm
 import sys
 import os

--- a/src/coral_complexity_metrics/mesh/shading.py
+++ b/src/coral_complexity_metrics/mesh/shading.py
@@ -8,7 +8,10 @@ from typing import Optional, Tuple, Dict, Any, Union
 import warnings
 from datetime import datetime
 import math
-from ._internal._shading_utils import AABB, BVHNode
+# ``AABB`` and ``BVHNode`` utilities live next to this module. Historically
+# they were accessed via ``_internal`` but the subpackage no longer contains
+# separate modules. Import directly to avoid failing lookups.
+from ._shading_utils import AABB, BVHNode
 
 
 class Shading:
@@ -520,12 +523,13 @@ class Shading:
                     (chunk, bvh_root, triangles, indices, light_dir) for chunk in chunks])
         
         shadowed = np.concatenate(results)
-        shaded_percentage = np.mean(shadowed) * 100
+        shaded_percentage_value = np.mean(shadowed) * 100
 
+        # Format percentages to two decimal places for user-facing results.
         result = {
             'mesh_file': self.mesh_file,
-            'shaded_percentage': shaded_percentage,
-            'illuminated_percentage': 100 - shaded_percentage,
+            'shaded_percentage': f"{shaded_percentage_value:.2f}%",
+            'illuminated_percentage': f"{100 - shaded_percentage_value:.2f}%",
             'sample_points': len(sampled_points),
             'cpu_cores_used': self.cpu_limit,
             'parameters': {
@@ -542,7 +546,7 @@ class Shading:
         }
 
         if verbose:
-            print(f"Shading calculation complete: {shaded_percentage:.2f}% shaded")
+            print(f"Shading calculation complete: {shaded_percentage_value:.2f}% shaded")
 
         return result
 


### PR DESCRIPTION
## Summary
- correct module paths in internal package
- expose `QuadratMetrics` and `GeometricMeasures` at top level
- fix imports in `quadrat_metrics` and `shading`
- return formatted shading percentages

## Testing
- `PYTHONPATH=src pytest tests/test_shading.py::test_calculate_shading_obj -q`

------
https://chatgpt.com/codex/tasks/task_e_683f51b595348328bc071dea2e99e27a